### PR TITLE
Upgrades resque to version 1.25.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ruby-version
 vendor/cache
+.bundle/config

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     url_checker (0.1)
-      resque (~> 1.20.0)
+      resque (~> 1.25.2)
 
 GEM
   remote: http://rubygems.org/
@@ -17,7 +17,8 @@ GEM
     debugger-ruby_core_source (1.3.8)
     diff-lcs (1.2.5)
     method_source (0.8.2)
-    multi_json (1.10.1)
+    mono_logger (1.1.0)
+    multi_json (1.11.2)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -25,15 +26,16 @@ GEM
     pry-debugger (0.2.3)
       debugger (~> 1.3)
       pry (>= 0.9.10, < 0.11.0)
-    rack (1.6.0)
+    rack (1.6.4)
     rack-protection (1.5.3)
       rack
-    redis (2.2.2)
-    redis-namespace (1.0.4)
-      redis (< 3.0.0)
-    resque (1.20.0)
+    redis (3.2.2)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
+    resque (1.25.2)
+      mono_logger (~> 1.0)
       multi_json (~> 1.0)
-      redis-namespace (~> 1.0.2)
+      redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
     rspec (3.2.0)
@@ -49,12 +51,12 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
-    sinatra (1.4.5)
+    sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
+      tilt (>= 1.3, < 3)
     slop (3.6.0)
-    tilt (1.4.1)
+    tilt (2.0.1)
     vegas (0.1.11)
       rack (>= 1.0.0)
 

--- a/url_checker.gemspec
+++ b/url_checker.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_dependency('resque', '~> 1.20.0')
+  s.add_dependency('resque', '~> 1.25.2')
 end


### PR DESCRIPTION
I need to upgrade the version of resque url_checker is using in order to be able to upgrade an app using it to rails 4. I ran the specs and didnt see anything broken. Let me know if there are any issues I am not seeing.
